### PR TITLE
Refactor: Support multiple relays; allow dynamic endpoint list

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,19 @@ services:
     networks:
       - rtmp-net
 
-  output-rtmp:
+  output-rtmp-1:
     image: tiangolo/nginx-rtmp
-    container_name: output-rtmp
+    container_name: output-rtmp-1
     ports:
       - "1935:1935"
+    networks:
+      - rtmp-net
+
+  output-rtmp-2:
+    image: tiangolo/nginx-rtmp
+    container_name: output-rtmp-2
+    ports:
+      - "1936:1935"
     networks:
       - rtmp-net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,15 @@
 version: '3.8'
 services:
-  input-rtmp:
+  input-rtmp-1:
     image: tiangolo/nginx-rtmp
-    container_name: input-rtmp
+    container_name: input-rtmp-1
+    ports:
+      - "1933:1935"
+    networks:
+      - rtmp-net
+  input-rtmp-2:
+    image: tiangolo/nginx-rtmp
+    container_name: input-rtmp-2
     ports:
       - "1934:1935"
     networks:
@@ -24,14 +31,35 @@ services:
     networks:
       - rtmp-net
 
+  output-rtmp-3:
+    image: tiangolo/nginx-rtmp
+    container_name: output-rtmp-3
+    ports:
+      - "1937:1935"
+    networks:
+      - rtmp-net
+
+  output-rtmp-4:
+    image: tiangolo/nginx-rtmp
+    container_name: output-rtmp-4
+    ports:
+      - "1938:1935"
+    networks:
+      - rtmp-net
+
   ffmpeg-source:
     image: linuxserver/ffmpeg
     container_name: ffmpeg-source
     depends_on:
-      - input-rtmp
+      - input-rtmp-1
+      - input-rtmp-2
     volumes:
       - ./testdata:/testdata:ro
-    entrypoint: ["ffmpeg", "-stream_loop", "-1", "-re", "-i", "/testdata/testsrc.mp4", "-c:v", "libx264", "-f", "flv", "rtmp://input-rtmp/live/stream"]
+    entrypoint: [
+      "sh", "-c",
+      "ffmpeg -stream_loop -1 -re -i /testdata/testsrc.mp4 -c:v libx264 -f flv rtmp://input-rtmp-1/live/stream & \
+       ffmpeg -stream_loop -1 -re -i /testdata/testsrc.mp4 -c:v libx264 -f flv rtmp://input-rtmp-2/live/stream && wait"
+    ]
     networks:
       - rtmp-net
 

--- a/internal/config/store.go
+++ b/internal/config/store.go
@@ -90,7 +90,7 @@ func (c *ConfigStore) Clean() error {
 		return err
 	}
 	for name, cfg := range configs {
-		if name == "" || (cfg.InputURL == "" && cfg.OutputURL == "") {
+		if name == "" || (cfg.InputURL == "" && (len(cfg.OutputURLs) == 0 || allEmpty(cfg.OutputURLs))) {
 			delete(configs, name)
 		}
 	}
@@ -102,6 +102,16 @@ func (c *ConfigStore) Clean() error {
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "    ")
 	return encoder.Encode(configs)
+}
+
+// allEmpty returns true if all strings in the slice are empty
+func allEmpty(urls []string) bool {
+	for _, u := range urls {
+		if u != "" {
+			return false
+		}
+	}
+	return true
 }
 
 func (c *ConfigStore) loadAll(target *map[string]stream.RTMPRelayConfig) error {

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,48 @@
+package logger
+
+import (
+	"log"
+	"os"
+)
+
+type LogLevel int
+
+const (
+	DEBUG LogLevel = iota
+	INFO
+	WARN
+	ERROR
+)
+
+type Logger struct {
+	level LogLevel
+}
+
+func NewLogger() *Logger {
+	lvl := INFO
+	if os.Getenv("GO_MLS_DEBUG") == "1" {
+		lvl = DEBUG
+	}
+	return &Logger{level: lvl}
+}
+
+func (l *Logger) Debug(msg string, args ...interface{}) {
+	if l.level <= DEBUG {
+		log.Printf("[DEBUG] "+msg, args...)
+	}
+}
+func (l *Logger) Info(msg string, args ...interface{}) {
+	if l.level <= INFO {
+		log.Printf("[INFO] "+msg, args...)
+	}
+}
+func (l *Logger) Warn(msg string, args ...interface{}) {
+	if l.level <= WARN {
+		log.Printf("[WARN] "+msg, args...)
+	}
+}
+func (l *Logger) Error(msg string, args ...interface{}) {
+	if l.level <= ERROR {
+		log.Printf("[ERROR] "+msg, args...)
+	}
+}

--- a/internal/stream/relay_manager.go
+++ b/internal/stream/relay_manager.go
@@ -1,0 +1,171 @@
+package stream
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"sync"
+)
+
+type RelayPair struct {
+	InputURL  string
+	OutputURL string
+	Cmd       *exec.Cmd
+	Running   bool
+	Bitrate   float64 // in kbits/s
+	mu        sync.Mutex
+}
+
+type RelayManager struct {
+	Pairs map[string]*RelayPair // Key: "inputURL|outputURL"
+	mu    sync.Mutex
+}
+
+func NewRelayManager() *RelayManager {
+	return &RelayManager{
+		Pairs: make(map[string]*RelayPair),
+	}
+}
+
+func relayKey(input, output string) string {
+	return input + "|" + output
+}
+
+// StartRelay starts an FFmpeg process for a given input-output pair and monitors it
+func (rm *RelayManager) StartRelay(inputURL, outputURL string) error {
+	rm.mu.Lock()
+	key := relayKey(inputURL, outputURL)
+	if pair, exists := rm.Pairs[key]; exists && pair.Running {
+		rm.mu.Unlock()
+		return fmt.Errorf("relay %s already running", key)
+	}
+	cmd := exec.Command("ffmpeg", "-re", "-i", inputURL, "-c", "copy", "-f", "flv", outputURL)
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		rm.mu.Unlock()
+		return fmt.Errorf("failed to create stderr pipe: %v", err)
+	}
+	err = cmd.Start()
+	if err != nil {
+		rm.mu.Unlock()
+		return fmt.Errorf("failed to start FFmpeg: %v", err)
+	}
+	pair := &RelayPair{
+		InputURL:  inputURL,
+		OutputURL: outputURL,
+		Cmd:       cmd,
+		Running:   true,
+		Bitrate:   0.0,
+	}
+	rm.Pairs[key] = pair
+	rm.mu.Unlock()
+
+	// Parse output in a goroutine
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		bitrateRegex := regexp.MustCompile(`bitrate=([\d.]+)kbits/s`)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if matches := bitrateRegex.FindStringSubmatch(line); matches != nil {
+				if bitrate, err := strconv.ParseFloat(matches[1], 64); err == nil {
+					pair.mu.Lock()
+					pair.Bitrate = bitrate
+					pair.mu.Unlock()
+				}
+			}
+		}
+	}()
+
+	// Monitor process
+	go func() {
+		err := cmd.Wait()
+		pair.mu.Lock()
+		pair.Running = false
+		pair.mu.Unlock()
+		if err != nil {
+			// Optionally: restart or log error
+		}
+	}()
+
+	return nil
+}
+
+// StopRelay stops an FFmpeg process for a given input-output pair
+func (rm *RelayManager) StopRelay(inputURL, outputURL string) error {
+	key := relayKey(inputURL, outputURL)
+	rm.mu.Lock()
+	pair, exists := rm.Pairs[key]
+	rm.mu.Unlock()
+	if !exists || !pair.Running {
+		return fmt.Errorf("relay %s not running", key)
+	}
+	return pair.Cmd.Process.Kill()
+}
+
+// Status returns the status and bitrate of all relays
+type RelayStatus struct {
+	Running bool    `json:"running"`
+	Bitrate float64 `json:"bitrate"`
+}
+
+func (rm *RelayManager) Status() map[string]RelayStatus {
+	status := make(map[string]RelayStatus)
+	rm.mu.Lock()
+	for key, pair := range rm.Pairs {
+		pair.mu.Lock()
+		status[key] = RelayStatus{Running: pair.Running, Bitrate: pair.Bitrate}
+		pair.mu.Unlock()
+	}
+	rm.mu.Unlock()
+	return status
+}
+
+// RelayConfigExport is a serializable struct for exporting relay configs
+type RelayConfigExport struct {
+	InputURL  string `json:"input_url"`
+	OutputURL string `json:"output_url"`
+}
+
+// ExportConfig saves the current relay configurations to a file (only serializable fields)
+func (rm *RelayManager) ExportConfig(filename string) error {
+	rm.mu.Lock()
+	defer rm.mu.Unlock()
+	exportMap := make(map[string]RelayConfigExport)
+	for key, pair := range rm.Pairs {
+		exportMap[key] = RelayConfigExport{
+			InputURL:  pair.InputURL,
+			OutputURL: pair.OutputURL,
+		}
+	}
+	data, err := json.MarshalIndent(exportMap, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filename, data, 0644)
+}
+
+// ImportConfig loads relay configurations from a file and starts them
+func (rm *RelayManager) ImportConfig(filename string) error {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return err
+	}
+	var pairs map[string]*RelayPair
+	err = json.Unmarshal(data, &pairs)
+	if err != nil {
+		return err
+	}
+	rm.mu.Lock()
+	for key, pair := range pairs {
+		rm.Pairs[key] = pair
+		rm.mu.Unlock()
+		rm.StartRelay(pair.InputURL, pair.OutputURL)
+		rm.mu.Lock()
+	}
+	rm.mu.Unlock()
+	return nil
+}

--- a/internal/stream/relay_manager.go
+++ b/internal/stream/relay_manager.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 )
 
-type RelayPair struct {
-	InputURL  string
+// RelayEndpoint manages a single output URL and its ffmpeg process
+type RelayEndpoint struct {
 	OutputURL string
 	Cmd       *exec.Cmd
 	Running   bool
@@ -20,49 +20,62 @@ type RelayPair struct {
 	mu        sync.Mutex
 }
 
+// Relay manages all endpoints for a single input URL
+type Relay struct {
+	InputURL  string
+	Endpoints map[string]*RelayEndpoint // key: output URL
+	mu        sync.Mutex
+}
+
+// RelayManager manages all relays (per input URL)
 type RelayManager struct {
-	Pairs map[string]*RelayPair // Key: "inputURL|outputURL"
-	mu    sync.Mutex
+	Relays map[string]*Relay // key: input URL
+	mu     sync.Mutex
 }
 
 func NewRelayManager() *RelayManager {
 	return &RelayManager{
-		Pairs: make(map[string]*RelayPair),
+		Relays: make(map[string]*Relay),
 	}
 }
 
-func relayKey(input, output string) string {
-	return input + "|" + output
-}
-
-// StartRelay starts an FFmpeg process for a given input-output pair and monitors it
+// StartRelay starts a relay for an input URL and output URL
 func (rm *RelayManager) StartRelay(inputURL, outputURL string) error {
 	rm.mu.Lock()
-	key := relayKey(inputURL, outputURL)
-	if pair, exists := rm.Pairs[key]; exists && pair.Running {
-		rm.mu.Unlock()
-		return fmt.Errorf("relay %s already running", key)
+	relay, exists := rm.Relays[inputURL]
+	if !exists {
+		relay = &Relay{
+			InputURL:  inputURL,
+			Endpoints: make(map[string]*RelayEndpoint),
+		}
+		rm.Relays[inputURL] = relay
+	}
+	rm.mu.Unlock()
+
+	relay.mu.Lock()
+	if ep, exists := relay.Endpoints[outputURL]; exists && ep.Running {
+		relay.mu.Unlock()
+		return fmt.Errorf("relay already running for %s -> %s", inputURL, outputURL)
 	}
 	cmd := exec.Command("ffmpeg", "-re", "-i", inputURL, "-c", "copy", "-f", "flv", outputURL)
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		rm.mu.Unlock()
+		relay.mu.Unlock()
 		return fmt.Errorf("failed to create stderr pipe: %v", err)
 	}
 	err = cmd.Start()
 	if err != nil {
-		rm.mu.Unlock()
+		relay.mu.Unlock()
 		return fmt.Errorf("failed to start FFmpeg: %v", err)
 	}
-	pair := &RelayPair{
-		InputURL:  inputURL,
+	ep := &RelayEndpoint{
 		OutputURL: outputURL,
 		Cmd:       cmd,
 		Running:   true,
 		Bitrate:   0.0,
 	}
-	rm.Pairs[key] = pair
-	rm.mu.Unlock()
+	relay.Endpoints[outputURL] = ep
+	relay.mu.Unlock()
 
 	// Parse output in a goroutine
 	go func() {
@@ -72,9 +85,9 @@ func (rm *RelayManager) StartRelay(inputURL, outputURL string) error {
 			line := scanner.Text()
 			if matches := bitrateRegex.FindStringSubmatch(line); matches != nil {
 				if bitrate, err := strconv.ParseFloat(matches[1], 64); err == nil {
-					pair.mu.Lock()
-					pair.Bitrate = bitrate
-					pair.mu.Unlock()
+					ep.mu.Lock()
+					ep.Bitrate = bitrate
+					ep.mu.Unlock()
 				}
 			}
 		}
@@ -83,9 +96,9 @@ func (rm *RelayManager) StartRelay(inputURL, outputURL string) error {
 	// Monitor process
 	go func() {
 		err := cmd.Wait()
-		pair.mu.Lock()
-		pair.Running = false
-		pair.mu.Unlock()
+		ep.mu.Lock()
+		ep.Running = false
+		ep.mu.Unlock()
 		if err != nil {
 			// Optionally: restart or log error
 		}
@@ -94,78 +107,100 @@ func (rm *RelayManager) StartRelay(inputURL, outputURL string) error {
 	return nil
 }
 
-// StopRelay stops an FFmpeg process for a given input-output pair
+// StopRelay stops a relay endpoint for an input/output URL
 func (rm *RelayManager) StopRelay(inputURL, outputURL string) error {
-	key := relayKey(inputURL, outputURL)
 	rm.mu.Lock()
-	pair, exists := rm.Pairs[key]
+	relay, exists := rm.Relays[inputURL]
 	rm.mu.Unlock()
-	if !exists || !pair.Running {
-		return fmt.Errorf("relay %s not running", key)
+	if !exists {
+		return fmt.Errorf("no relay for input %s", inputURL)
 	}
-	return pair.Cmd.Process.Kill()
+	relay.mu.Lock()
+	ep, exists := relay.Endpoints[outputURL]
+	relay.mu.Unlock()
+	if !exists || !ep.Running {
+		return fmt.Errorf("relay not running for %s -> %s", inputURL, outputURL)
+	}
+	return ep.Cmd.Process.Kill()
 }
 
 // Status returns the status and bitrate of all relays
 type RelayStatus struct {
-	Running bool    `json:"running"`
-	Bitrate float64 `json:"bitrate"`
+	InputURL  string `json:"input_url"`
+	Endpoints []struct {
+		OutputURL string  `json:"output_url"`
+		Running   bool    `json:"running"`
+		Bitrate   float64 `json:"bitrate"`
+	} `json:"endpoints"`
 }
 
-func (rm *RelayManager) Status() map[string]RelayStatus {
-	status := make(map[string]RelayStatus)
+func (rm *RelayManager) Status() []RelayStatus {
+	statuses := []RelayStatus{}
 	rm.mu.Lock()
-	for key, pair := range rm.Pairs {
-		pair.mu.Lock()
-		status[key] = RelayStatus{Running: pair.Running, Bitrate: pair.Bitrate}
-		pair.mu.Unlock()
+	for _, relay := range rm.Relays {
+		relay.mu.Lock()
+		endpoints := []struct {
+			OutputURL string  `json:"output_url"`
+			Running   bool    `json:"running"`
+			Bitrate   float64 `json:"bitrate"`
+		}{}
+		for _, ep := range relay.Endpoints {
+			ep.mu.Lock()
+			endpoints = append(endpoints, struct {
+				OutputURL string  `json:"output_url"`
+				Running   bool    `json:"running"`
+				Bitrate   float64 `json:"bitrate"`
+			}{OutputURL: ep.OutputURL, Running: ep.Running, Bitrate: ep.Bitrate})
+			ep.mu.Unlock()
+		}
+		statuses = append(statuses, RelayStatus{
+			InputURL:  relay.InputURL,
+			Endpoints: endpoints,
+		})
+		relay.mu.Unlock()
 	}
 	rm.mu.Unlock()
-	return status
+	return statuses
 }
 
-// RelayConfigExport is a serializable struct for exporting relay configs
-type RelayConfigExport struct {
-	InputURL  string `json:"input_url"`
-	OutputURL string `json:"output_url"`
-}
-
-// ExportConfig saves the current relay configurations to a file (only serializable fields)
+// ExportConfig saves the current relay configurations to a file (grouped by input URL)
 func (rm *RelayManager) ExportConfig(filename string) error {
+	type exportConfig map[string][]string // input_url -> []output_url
 	rm.mu.Lock()
-	defer rm.mu.Unlock()
-	exportMap := make(map[string]RelayConfigExport)
-	for key, pair := range rm.Pairs {
-		exportMap[key] = RelayConfigExport{
-			InputURL:  pair.InputURL,
-			OutputURL: pair.OutputURL,
+	cfg := make(exportConfig)
+	for _, relay := range rm.Relays {
+		relay.mu.Lock()
+		var outputs []string
+		for _, ep := range relay.Endpoints {
+			outputs = append(outputs, ep.OutputURL)
 		}
+		cfg[relay.InputURL] = outputs
+		relay.mu.Unlock()
 	}
-	data, err := json.MarshalIndent(exportMap, "", "  ")
+	rm.mu.Unlock()
+	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(filename, data, 0644)
 }
 
-// ImportConfig loads relay configurations from a file and starts them
+// ImportConfig loads relay configurations from a file (grouped by input URL)
 func (rm *RelayManager) ImportConfig(filename string) error {
+	type importConfig map[string][]string
 	data, err := os.ReadFile(filename)
 	if err != nil {
 		return err
 	}
-	var pairs map[string]*RelayPair
-	err = json.Unmarshal(data, &pairs)
+	var cfg importConfig
+	err = json.Unmarshal(data, &cfg)
 	if err != nil {
 		return err
 	}
-	rm.mu.Lock()
-	for key, pair := range pairs {
-		rm.Pairs[key] = pair
-		rm.mu.Unlock()
-		rm.StartRelay(pair.InputURL, pair.OutputURL)
-		rm.mu.Lock()
+	for input, outputs := range cfg {
+		for _, output := range outputs {
+			rm.StartRelay(input, output)
+		}
 	}
-	rm.mu.Unlock()
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -13,16 +13,7 @@ import (
 var (
 	relayMgr = stream.NewRelayManager()
 	logr     = config.NewLogger()
-	cfgStore = config.NewConfigStore("relay_config.json")
 )
-
-type StreamStatus struct {
-	Running    bool     `json:"running"`
-	Message    string   `json:"message"`
-	InputURL   string   `json:"input_url,omitempty"`
-	OutputURLs []string `json:"output_urls,omitempty"`
-	LastCmds   []string `json:"last_cmds,omitempty"`
-}
 
 func apiStartRelay(w http.ResponseWriter, r *http.Request) {
 	var req struct {

--- a/main.go
+++ b/main.go
@@ -6,103 +6,134 @@ import (
 	"net/http"
 	"os"
 
-	"go-mls/internal/config"
+	"go-mls/internal/logger"
 	"go-mls/internal/stream"
 )
 
-var (
-	relayMgr = stream.NewRelayManager()
-	logr     = config.NewLogger()
-)
-
-func apiStartRelay(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		InputURL  string `json:"input_url"`
-		OutputURL string `json:"output_url"`
+func apiStartRelay(relayMgr *stream.RelayManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		relayMgr.Logger.Debug("apiStartRelay called")
+		var req struct {
+			InputURL  string `json:"input_url"`
+			OutputURL string `json:"output_url"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			relayMgr.Logger.Debug("apiStartRelay: failed to decode request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request"})
+			return
+		}
+		relayMgr.Logger.Debug("apiStartRelay: starting relay for input=%s, output=%s", req.InputURL, req.OutputURL)
+		if err := relayMgr.StartRelay(req.InputURL, req.OutputURL); err != nil {
+			relayMgr.Logger.Debug("apiStartRelay: failed to start relay: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"status": "started"})
+		relayMgr.Logger.Debug("apiStartRelay: relay started successfully")
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request"})
-		return
-	}
-	if err := relayMgr.StartRelay(req.InputURL, req.OutputURL); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		return
-	}
-	json.NewEncoder(w).Encode(map[string]string{"status": "started"})
 }
 
-func apiStopRelay(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		InputURL  string `json:"input_url"`
-		OutputURL string `json:"output_url"`
+func apiStopRelay(relayMgr *stream.RelayManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		relayMgr.Logger.Debug("apiStopRelay called")
+		var req struct {
+			InputURL  string `json:"input_url"`
+			OutputURL string `json:"output_url"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			relayMgr.Logger.Debug("apiStopRelay: failed to decode request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request"})
+			return
+		}
+		relayMgr.Logger.Debug("apiStopRelay: stopping relay for input=%s, output=%s", req.InputURL, req.OutputURL)
+		if err := relayMgr.StopRelay(req.InputURL, req.OutputURL); err != nil {
+			relayMgr.Logger.Debug("apiStopRelay: failed to stop relay: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"status": "stopped"})
+		relayMgr.Logger.Debug("apiStopRelay: relay stopped successfully")
 	}
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request"})
-		return
-	}
-	if err := relayMgr.StopRelay(req.InputURL, req.OutputURL); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		return
-	}
-	json.NewEncoder(w).Encode(map[string]string{"status": "stopped"})
 }
 
-func apiRelayStatus(w http.ResponseWriter, r *http.Request) {
-	json.NewEncoder(w).Encode(relayMgr.Status())
+func apiRelayStatus(relayMgr *stream.RelayManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		relayMgr.Logger.Debug("apiRelayStatus called")
+		json.NewEncoder(w).Encode(relayMgr.Status())
+		relayMgr.Logger.Debug("apiRelayStatus: status returned")
+	}
 }
 
-func apiExportRelays(w http.ResponseWriter, r *http.Request) {
-	if err := relayMgr.ExportConfig("relay_config.json"); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		return
+func apiExportRelays(relayMgr *stream.RelayManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		relayMgr.Logger.Debug("apiExportRelays called")
+		if err := relayMgr.ExportConfig("relay_config.json"); err != nil {
+			relayMgr.Logger.Debug("apiExportRelays: failed to export config: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Disposition", "attachment; filename=relay_config.json")
+		data, _ := os.ReadFile("relay_config.json")
+		w.Write(data)
+		relayMgr.Logger.Debug("apiExportRelays: config exported successfully")
 	}
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Content-Disposition", "attachment; filename=relay_config.json")
-	data, _ := os.ReadFile("relay_config.json")
-	w.Write(data)
 }
 
-func apiImportRelays(w http.ResponseWriter, r *http.Request) {
-	file, _, err := r.FormFile("file")
-	if err != nil {
-		w.WriteHeader(http.StatusBadRequest)
-		json.NewEncoder(w).Encode(map[string]string{"error": "No file uploaded"})
-		return
+func apiImportRelays(relayMgr *stream.RelayManager) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		relayMgr.Logger.Debug("apiImportRelays called")
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			relayMgr.Logger.Debug("apiImportRelays: no file uploaded: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			json.NewEncoder(w).Encode(map[string]string{"error": "No file uploaded"})
+			return
+		}
+		defer file.Close()
+		f, err := os.Create("relay_config.json")
+		if err != nil {
+			relayMgr.Logger.Debug("apiImportRelays: failed to save file: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": "Failed to save file"})
+			return
+		}
+		defer f.Close()
+		io.Copy(f, file)
+		if err := relayMgr.ImportConfig("relay_config.json"); err != nil {
+			relayMgr.Logger.Debug("apiImportRelays: failed to import config: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"status": "imported"})
+		relayMgr.Logger.Debug("apiImportRelays: config imported successfully")
 	}
-	defer file.Close()
-	f, err := os.Create("relay_config.json")
-	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": "Failed to save file"})
-		return
-	}
-	defer f.Close()
-	io.Copy(f, file)
-	if err := relayMgr.ImportConfig("relay_config.json"); err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
-		return
-	}
-	json.NewEncoder(w).Encode(map[string]string{"status": "imported"})
 }
 
 func main() {
+	logger := logger.NewLogger()
+	logger.Debug("main: initializing relay manager")
+	relayMgr := stream.NewRelayManager(logger)
+
 	fs := http.FileServer(http.Dir("web/static"))
 	http.Handle("/static/", http.StripPrefix("/static/", fs))
 
-	http.HandleFunc("/api/relay/start", apiStartRelay)
-	http.HandleFunc("/api/relay/stop", apiStopRelay)
-	http.HandleFunc("/api/relay/status", apiRelayStatus)
-	http.HandleFunc("/api/relay/export", apiExportRelays)
-	http.HandleFunc("/api/relay/import", apiImportRelays)
+	http.HandleFunc("/api/relay/start", apiStartRelay(relayMgr))
+	http.HandleFunc("/api/relay/stop", apiStopRelay(relayMgr))
+	http.HandleFunc("/api/relay/status", apiRelayStatus(relayMgr))
+	http.HandleFunc("/api/relay/export", apiExportRelays(relayMgr))
+	http.HandleFunc("/api/relay/import", apiImportRelays(relayMgr))
 
-	logr.Info("Go-MLS relay manager running at http://localhost:8080 ...")
+	logger.Info("Go-MLS relay manager running at http://localhost:8080 ...")
+	logger.Debug("main: server starting on :8080")
 	if err := http.ListenAndServe(":8080", nil); err != nil {
-		logr.Error("Server error: %v", err)
+		logger.Error("Server error: %v", err)
 	}
+	logger.Debug("main: server shutdown")
 }

--- a/main.go
+++ b/main.go
@@ -18,14 +18,14 @@ func apiStartRelay(relayMgr *stream.RelayManager) http.HandlerFunc {
 			OutputURL string `json:"output_url"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			relayMgr.Logger.Debug("apiStartRelay: failed to decode request: %v", err)
+			relayMgr.Logger.Error("apiStartRelay: failed to decode request: %v", err)
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request"})
 			return
 		}
 		relayMgr.Logger.Debug("apiStartRelay: starting relay for input=%s, output=%s", req.InputURL, req.OutputURL)
 		if err := relayMgr.StartRelay(req.InputURL, req.OutputURL); err != nil {
-			relayMgr.Logger.Debug("apiStartRelay: failed to start relay: %v", err)
+			relayMgr.Logger.Error("apiStartRelay: failed to start relay: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 			return
@@ -43,14 +43,14 @@ func apiStopRelay(relayMgr *stream.RelayManager) http.HandlerFunc {
 			OutputURL string `json:"output_url"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			relayMgr.Logger.Debug("apiStopRelay: failed to decode request: %v", err)
+			relayMgr.Logger.Error("apiStopRelay: failed to decode request: %v", err)
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{"error": "Invalid request"})
 			return
 		}
 		relayMgr.Logger.Debug("apiStopRelay: stopping relay for input=%s, output=%s", req.InputURL, req.OutputURL)
 		if err := relayMgr.StopRelay(req.InputURL, req.OutputURL); err != nil {
-			relayMgr.Logger.Debug("apiStopRelay: failed to stop relay: %v", err)
+			relayMgr.Logger.Error("apiStopRelay: failed to stop relay: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 			return
@@ -72,7 +72,7 @@ func apiExportRelays(relayMgr *stream.RelayManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		relayMgr.Logger.Debug("apiExportRelays called")
 		if err := relayMgr.ExportConfig("relay_config.json"); err != nil {
-			relayMgr.Logger.Debug("apiExportRelays: failed to export config: %v", err)
+			relayMgr.Logger.Error("apiExportRelays: failed to export config: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 			return
@@ -90,7 +90,7 @@ func apiImportRelays(relayMgr *stream.RelayManager) http.HandlerFunc {
 		relayMgr.Logger.Debug("apiImportRelays called")
 		file, _, err := r.FormFile("file")
 		if err != nil {
-			relayMgr.Logger.Debug("apiImportRelays: no file uploaded: %v", err)
+			relayMgr.Logger.Error("apiImportRelays: no file uploaded: %v", err)
 			w.WriteHeader(http.StatusBadRequest)
 			json.NewEncoder(w).Encode(map[string]string{"error": "No file uploaded"})
 			return
@@ -98,7 +98,7 @@ func apiImportRelays(relayMgr *stream.RelayManager) http.HandlerFunc {
 		defer file.Close()
 		f, err := os.Create("relay_config.json")
 		if err != nil {
-			relayMgr.Logger.Debug("apiImportRelays: failed to save file: %v", err)
+			relayMgr.Logger.Error("apiImportRelays: failed to save file: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(map[string]string{"error": "Failed to save file"})
 			return
@@ -106,7 +106,7 @@ func apiImportRelays(relayMgr *stream.RelayManager) http.HandlerFunc {
 		defer f.Close()
 		io.Copy(f, file)
 		if err := relayMgr.ImportConfig("relay_config.json"); err != nil {
-			relayMgr.Logger.Debug("apiImportRelays: failed to import config: %v", err)
+			relayMgr.Logger.Error("apiImportRelays: failed to import config: %v", err)
 			w.WriteHeader(http.StatusInternalServerError)
 			json.NewEncoder(w).Encode(map[string]string{"error": err.Error()})
 			return

--- a/relay_config.json
+++ b/relay_config.json
@@ -1,6 +1,9 @@
 {
     "docker": {
         "input_url": "rtmp://localhost:1934/live/stream",
-        "output_url": "rtmp://localhost/live/stream"
+        "output_urls": [
+            "rtmp://localhost:1935/live/stream",
+            "rtmp://localhost:1936/live/stream"
+        ]
     }
 }

--- a/relay_config.json
+++ b/relay_config.json
@@ -1,9 +1,10 @@
 {
-    "docker": {
-        "input_url": "rtmp://localhost:1934/live/stream",
-        "output_urls": [
-            "rtmp://localhost:1935/live/stream",
-            "rtmp://localhost:1936/live/stream"
-        ]
-    }
+  "rtmp://localhost:1934/live/stream|rtmp://localhost:1935/live/stream": {
+    "input_url": "rtmp://localhost:1934/live/stream",
+    "output_url": "rtmp://localhost:1935/live/stream"
+  },
+  "rtmp://localhost:1934/live/stream|rtmp://localhost:1936/live/stream": {
+    "input_url": "rtmp://localhost:1934/live/stream",
+    "output_url": "rtmp://localhost:1936/live/stream"
+  }
 }

--- a/relay_config.json
+++ b/relay_config.json
@@ -1,10 +1,10 @@
 {
-  "rtmp://localhost:1934/live/stream|rtmp://localhost:1935/live/stream": {
-    "input_url": "rtmp://localhost:1934/live/stream",
-    "output_url": "rtmp://localhost:1935/live/stream"
-  },
-  "rtmp://localhost:1934/live/stream|rtmp://localhost:1936/live/stream": {
-    "input_url": "rtmp://localhost:1934/live/stream",
-    "output_url": "rtmp://localhost:1936/live/stream"
-  }
+  "rtmp://localhost:1933/live/stream": [
+    "rtmp://localhost:1935/live/stream",
+    "rtmp://localhost:1936/live/stream"
+  ],
+  "rtmp://localhost:1934/live/stream": [
+    "rtmp://localhost:1937/live/stream",
+    "rtmp://localhost:1938/live/stream"
+  ]
 }

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -26,22 +26,39 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!data || data.length === 0) {
             html += '<i>No relays running.</i>';
         } else {
+            // Sort relays by input_url (alphanumeric ascending)
+            data.sort((a, b) => a.input_url.localeCompare(b.input_url, undefined, {numeric: true, sensitivity: 'base'}));
+            html += `<table style="width:100%;border-collapse:collapse;">
+                <tr>
+                    <th>Input URL</th>
+                    <th>Output URL</th>
+                    <th>Status</th>
+                    <th>Bitrate (kbps)</th>
+                    <th>Action</th>
+                </tr>`;
             for (const relay of data) {
                 const input = relay.input_url;
-                html += `<div style="margin-bottom:24px;">
-                    <div style="font-weight:bold; font-size:16px; margin-bottom:4px;">Input: <span style="color:#1976d2">${input}</span></div>
-                    <table style="width:100%;border-collapse:collapse;">
-                    <tr><th>Output URL</th><th>Status</th><th>Bitrate (kbps)</th><th>Action</th></tr>`;
-                for (const ep of relay.endpoints) {
+                // Sort endpoints by output_url (alphanumeric ascending)
+                const endpoints = relay.endpoints ? relay.endpoints.slice().sort((a, b) => (a.output_url || '').localeCompare(b.output_url || '', undefined, {numeric: true, sensitivity: 'base'})) : [];
+                if (endpoints.length === 0) {
                     html += `<tr>
-                        <td style="word-break:break-all;">${ep.output_url}</td>
-                        <td>${ep.running ? 'Running' : 'Stopped'}</td>
-                        <td>${ep.bitrate ? ep.bitrate : '-'}</td>
-                        <td><button class="stopRelayBtn" data-input="${input}" data-output="${ep.output_url}" ${!ep.running ? 'disabled' : ''}>Stop</button></td>
+                        <td style="word-break:break-all; color:#1976d2; font-weight:bold;">${input}</td>
+                        <td colspan="4"><i>No endpoints</i></td>
                     </tr>`;
+                } else {
+                    for (let i = 0; i < endpoints.length; i++) {
+                        const ep = endpoints[i];
+                        html += `<tr>
+                            ${i === 0 ? `<td rowspan="${endpoints.length}" style="word-break:break-all; color:#1976d2; font-weight:bold; vertical-align:middle;">${input}</td>` : ''}
+                            <td style="word-break:break-all;">${ep.output_url}</td>
+                            <td>${ep.running ? 'Running' : 'Stopped'}</td>
+                            <td>${ep.bitrate ? ep.bitrate : '-'}</td>
+                            <td><button class="stopRelayBtn" data-input="${input}" data-output="${ep.output_url}" ${!ep.running ? 'disabled' : ''}>Stop</button></td>
+                        </tr>`;
+                    }
                 }
-                html += '</table></div>';
             }
+            html += '</table>';
         }
         document.getElementById('relayTable').innerHTML = html;
 

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -33,7 +33,9 @@ document.addEventListener('DOMContentLoaded', function() {
                 statusDiv.innerHTML = `<b>Status:</b> ${data.message}` +
                     (data.input_url ? `<br><b>Input:</b> ${data.input_url}` : '') +
                     outputs + cmds;
+                // Button logic: Only Start enabled if not running, else Update/Stop enabled
                 document.getElementById('startBtn').disabled = data.running;
+                document.getElementById('updateBtn').disabled = !data.running;
                 document.getElementById('stopBtn').disabled = !data.running;
             });
     }
@@ -57,6 +59,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 (data.input_url ? `<br><b>Input:</b> ${data.input_url}` : '') +
                 outputs + cmds;
             document.getElementById('startBtn').disabled = data.status === 'running';
+            document.getElementById('updateBtn').disabled = data.status !== 'running';
             document.getElementById('stopBtn').disabled = data.status !== 'running';
         });
         es.addEventListener('logs', function(e) {
@@ -114,6 +117,7 @@ document.addEventListener('DOMContentLoaded', function() {
             <input id="importFile" type="file" accept="application/json" style="display:none" />
             <button id="importBtn" type="button">Import Configs</button><br>
             <button id="startBtn" type="submit">Start Relay</button>
+            <button id="updateBtn" type="button">Update Relay</button>
             <button id="stopBtn" type="button">Stop Relay</button>
             <button id="refreshBtn" type="button">Show Status</button>
         </form>
@@ -190,6 +194,22 @@ document.addEventListener('DOMContentLoaded', function() {
     };
     configSelect.onchange = function() {
         loadConfigByName(configSelect.value);
+    };
+
+    document.getElementById('updateBtn').onclick = function() {
+        const outputUrls = document.getElementById('outputUrls').value
+            .split(/\n|,/)
+            .map(s => s.trim())
+            .filter(Boolean);
+        fetch('/api/update', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                input_url: document.getElementById('inputUrl').value,
+                output_urls: outputUrls
+            })
+        })
+        .then(() => updateStatus());
     };
 
     updateStatus();

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,7 +1,5 @@
 document.addEventListener('DOMContentLoaded', function() {
     const relayControls = document.getElementById('controls');
-    const statusDiv = document.getElementById('status');
-    const logsDiv = document.getElementById('logs');
 
     // Render static input controls once
     relayControls.innerHTML = `<h2>Add Relay Endpoint</h2>
@@ -28,37 +26,45 @@ document.addEventListener('DOMContentLoaded', function() {
         } else {
             // Sort relays by input_url (alphanumeric ascending)
             data.sort((a, b) => a.input_url.localeCompare(b.input_url, undefined, {numeric: true, sensitivity: 'base'}));
-            html += `<table style="width:100%;border-collapse:collapse;">
-                <tr>
-                    <th>Input URL</th>
-                    <th>Output URL</th>
-                    <th>Status</th>
-                    <th>Bitrate (kbps)</th>
-                    <th>Action</th>
-                </tr>`;
-            for (const relay of data) {
+            html += `<table style="width:100%;border-collapse:separate;border-spacing:0;">
+                <thead>
+                    <tr>
+                        <th style="text-align:left; padding:8px 12px;">Input URL</th>
+                        <th style="text-align:left; padding:8px 12px;">Output URL</th>
+                        <th style="text-align:left; padding:8px 12px;">Status</th>
+                        <th style="text-align:left; padding:8px 12px;">Bitrate (kbps)</th>
+                        <th style="text-align:left; padding:8px 12px;">Action</th>
+                    </tr>
+                </thead>
+                <tbody>`;
+            for (let relayIdx = 0; relayIdx < data.length; relayIdx++) {
+                const relay = data[relayIdx];
                 const input = relay.input_url;
                 // Sort endpoints by output_url (alphanumeric ascending)
                 const endpoints = relay.endpoints ? relay.endpoints.slice().sort((a, b) => (a.output_url || '').localeCompare(b.output_url || '', undefined, {numeric: true, sensitivity: 'base'})) : [];
+                // Alternate input group background
+                const inputBg = relayIdx % 2 === 0 ? '#f7fafd' : '#f0f4fa';
+                const inputGroupBorder = 'border-top: 3px solid #b6d0f7;';
                 if (endpoints.length === 0) {
-                    html += `<tr>
-                        <td style="word-break:break-all; color:#1976d2; font-weight:bold;">${input}</td>
-                        <td colspan="4"><i>No endpoints</i></td>
+                    html += `<tr style="${inputGroupBorder}">
+                        <td style="word-break:break-all; color:#1976d2; font-weight:bold; padding:8px 12px; background:${inputBg};">${input}</td>
+                        <td colspan="4" style="padding:8px 12px; background:#fff;"><i>No endpoints</i></td>
                     </tr>`;
                 } else {
                     for (let i = 0; i < endpoints.length; i++) {
                         const ep = endpoints[i];
-                        html += `<tr>
-                            ${i === 0 ? `<td rowspan="${endpoints.length}" style="word-break:break-all; color:#1976d2; font-weight:bold; vertical-align:middle;">${input}</td>` : ''}
-                            <td style="word-break:break-all;">${ep.output_url}</td>
-                            <td>${ep.running ? 'Running' : 'Stopped'}</td>
-                            <td>${ep.bitrate ? ep.bitrate : '-'}</td>
-                            <td><button class="stopRelayBtn" data-input="${input}" data-output="${ep.output_url}" ${!ep.running ? 'disabled' : ''}>Stop</button></td>
+                        const outputBg = inputBg;
+                        html += `<tr style="${inputGroupBorder} background:${outputBg};">
+                            ${i === 0 ? `<td rowspan="${endpoints.length}" style="word-break:break-all; color:#1976d2; font-weight:bold; vertical-align:middle; padding:8px 12px; background:${inputBg}; border:none;">${input}</td>` : ''}
+                            <td style="word-break:break-all; padding:8px 12px;">${ep.output_url}</td>
+                            <td style="padding:8px 12px;">${ep.running ? 'Running' : 'Stopped'}</td>
+                            <td style="padding:8px 12px;">${ep.bitrate ? ep.bitrate : '-'}</td>
+                            <td style="padding:8px 12px;"><button class="stopRelayBtn" data-input="${input}" data-output="${ep.output_url}" ${!ep.running ? 'disabled' : ''}>Stop</button></td>
                         </tr>`;
                     }
                 }
             }
-            html += '</table>';
+            html += '</tbody></table>';
         }
         document.getElementById('relayTable').innerHTML = html;
 

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -1,216 +1,89 @@
 document.addEventListener('DOMContentLoaded', function() {
-    const controls = document.getElementById('controls');
+    const relayControls = document.getElementById('controls');
     const statusDiv = document.getElementById('status');
     const logsDiv = document.getElementById('logs');
-    let configSelect;
 
-    function updateLogs() {
-        fetch('/api/relay/logs')
+    // Render static input controls once
+    relayControls.innerHTML = `<h2>Add Relay</h2>
+        <input type="text" id="inputUrl" placeholder="Input URL" style="width:260px;">
+        <input type="text" id="outputUrl" placeholder="Output URL" style="width:260px;">
+        <button id="startRelayBtn">Start Relay</button>
+        <button id="exportBtn">Export Relays</button>
+        <input id="importFile" type="file" accept="application/json" style="display:none" />
+        <button id="importBtn">Import Relays</button>
+        <h2>Active Relays</h2>
+        <div id="relayTable"></div>`;
+
+    function fetchStatus() {
+        fetch('/api/relay/status')
             .then(r => r.json())
-            .then(data => {
-                if (data.logs && data.logs.length) {
-                    logsDiv.innerHTML = data.logs.map(l => l.replace(/</g,'&lt;')).join('<br>');
-                } else {
-                    logsDiv.innerHTML = '<i>No logs yet.</i>';
-                }
-            });
+            .then(data => updateUI(data));
     }
 
-    function updateStatus() {
-        fetch('/api/status')
-            .then(r => r.json())
-            .then(data => {
-                let outputs = '';
-                if (data.output_urls && data.output_urls.length) {
-                    outputs = `<br><b>Outputs:</b><ul style='margin:0 0 0 20px;padding:0;'>` +
-                        data.output_urls.map(url => `<li>${url}</li>`).join('') + '</ul>';
-                }
-                let cmds = '';
-                if (data.last_cmds && data.last_cmds.length) {
-                    cmds = `<br><b>Last Cmds:</b><ul style='margin:0 0 0 20px;padding:0;'>` +
-                        data.last_cmds.map(cmd => `<li><code>${cmd}</code></li>`).join('') + '</ul>';
-                }
-                statusDiv.innerHTML = `<b>Status:</b> ${data.message}` +
-                    (data.input_url ? `<br><b>Input:</b> ${data.input_url}` : '') +
-                    outputs + cmds;
-                // Button logic: Only Start enabled if not running, else Update/Stop enabled
-                document.getElementById('startBtn').disabled = data.running;
-                document.getElementById('updateBtn').disabled = !data.running;
-                document.getElementById('stopBtn').disabled = !data.running;
-            });
-    }
+    function updateUI(data) {
+        // Only update the relay table, not the input fields
+        let html = '';
+        if (Object.keys(data).length === 0) {
+            html += '<i>No relays running.</i>';
+        } else {
+            html += '<table style="width:100%;border-collapse:collapse;">';
+            html += '<tr><th>Input URL</th><th>Output URL</th><th>Status</th><th>Bitrate (kbps)</th><th>Action</th></tr>';
+            for (const key in data) {
+                const [input, output] = key.split('|');
+                const info = data[key];
+                html += `<tr>
+                    <td style="word-break:break-all;">${input}</td>
+                    <td style="word-break:break-all;">${output}</td>
+                    <td>${info.running ? 'Running' : 'Stopped'}</td>
+                    <td>${info.bitrate ? info.bitrate : '-'}</td>
+                    <td><button class="stopRelayBtn" data-key="${key}" ${!info.running ? 'disabled' : ''}>Stop</button></td>
+                </tr>`;
+            }
+            html += '</table>';
+        }
+        document.getElementById('relayTable').innerHTML = html;
 
-    function setupSSE() {
-        if (!window.EventSource) return false;
-        const es = new EventSource('/api/relay/events');
-        es.addEventListener('status', function(e) {
-            const data = JSON.parse(e.data);
-            let outputs = '';
-            if (data.output_urls && data.output_urls.length) {
-                outputs = `<br><b>Outputs:</b><ul style='margin:0 0 0 20px;padding:0;'>` +
-                    data.output_urls.map(url => `<li>${url}</li>`).join('') + '</ul>';
-            }
-            let cmds = '';
-            if (data.last_cmds && data.last_cmds.length) {
-                cmds = `<br><b>Last Cmds:</b><ul style='margin:0 0 0 20px;padding:0;'>` +
-                    data.last_cmds.map(cmd => `<li><code>${cmd}</code></li>`).join('') + '</ul>';
-            }
-            statusDiv.innerHTML = `<b>Status:</b> ${data.status === 'running' ? 'Stream running' : 'Idle'}` +
-                (data.input_url ? `<br><b>Input:</b> ${data.input_url}` : '') +
-                outputs + cmds;
-            document.getElementById('startBtn').disabled = data.status === 'running';
-            document.getElementById('updateBtn').disabled = data.status !== 'running';
-            document.getElementById('stopBtn').disabled = data.status !== 'running';
-        });
-        es.addEventListener('logs', function(e) {
-            const logs = JSON.parse(e.data);
-            if (logs && logs.length) {
-                logsDiv.innerHTML = logs.map(l => l.replace(/</g,'&lt;')).join('<br>');
-            } else {
-                logsDiv.innerHTML = '<i>No logs yet.</i>';
-            }
-        });
-        es.onerror = function() {
-            es.close();
-            // fallback to polling
-            setInterval(updateLogs, 2000);
-            setInterval(updateStatus, 2000);
+        // Add event listeners for start/stop
+        document.getElementById('startRelayBtn').onclick = function() {
+            const inputUrl = document.getElementById('inputUrl').value.trim();
+            const outputUrl = document.getElementById('outputUrl').value.trim();
+            if (!inputUrl || !outputUrl) { alert('Input and Output URL required'); return; }
+            fetch('/api/relay/start', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ input_url: inputUrl, output_url: outputUrl })
+            }).then(() => { fetchStatus(); });
         };
-        return true;
+        document.querySelectorAll('.stopRelayBtn').forEach(btn => {
+            btn.onclick = function() {
+                const key = btn.getAttribute('data-key');
+                const [input, output] = key.split('|');
+                fetch('/api/relay/stop', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ input_url: input, output_url: output })
+                }).then(() => { fetchStatus(); });
+            };
+        });
+        document.getElementById('exportBtn').onclick = function() {
+            window.location = '/api/relay/export';
+        };
+        document.getElementById('importBtn').onclick = function() {
+            document.getElementById('importFile').click();
+        };
+        document.getElementById('importFile').onchange = function(e) {
+            const file = e.target.files[0];
+            if (!file) return;
+            const formData = new FormData();
+            formData.append('file', file);
+            fetch('/api/relay/import', {
+                method: 'POST',
+                body: formData
+            }).then(() => { fetchStatus(); });
+        };
     }
 
-    if (!setupSSE()) {
-        setInterval(updateLogs, 2000);
-        setInterval(updateStatus, 2000);
-    }
-
-    function loadConfigList() {
-        fetch('/api/list-configs')
-            .then(r => r.json())
-            .then(names => {
-                configSelect.innerHTML = '<option value="">-- Select Saved Config --</option>' +
-                    names.map(n => `<option value="${n}">${n}</option>`).join('');
-            });
-    }
-
-    function loadConfigByName(name) {
-        if (!name) return;
-        fetch('/api/load-config?name=' + encodeURIComponent(name))
-            .then(r => r.json())
-            .then(cfg => {
-                if (cfg.input_url) document.getElementById('inputUrl').value = cfg.input_url;
-                if (cfg.output_urls) document.getElementById('outputUrls').value = Array.isArray(cfg.output_urls) ? cfg.output_urls.join('\n') : cfg.output_urls;
-            });
-    }
-
-    controls.innerHTML = `
-        <form id="relayForm" enctype="multipart/form-data">
-            <label>RTMP Input URL: <input type="text" id="inputUrl" required placeholder="rtmp://source/live/stream" style="width:300px"></label><br>
-            <label>RTMP Output URLs: <textarea id="outputUrls" required placeholder="rtmp://dest/live/stream1\nrtmp://dest/live/stream2" style="width:300px;height:48px;"></textarea></label><br>
-            <select id="configSelect"></select>
-            <button id="loadBtn" type="button">Load Config</button>
-            <button id="deleteBtn" type="button">Delete Config</button>
-            <input id="saveName" type="text" placeholder="Config name" style="width:150px" />
-            <button id="saveBtn" type="button">Save Config</button>
-            <button id="cleanBtn" type="button">Clean Empty/Invalid Configs</button><br>
-            <button id="exportBtn" type="button">Export Configs</button>
-            <input id="importFile" type="file" accept="application/json" style="display:none" />
-            <button id="importBtn" type="button">Import Configs</button><br>
-            <button id="startBtn" type="submit">Start Relay</button>
-            <button id="updateBtn" type="button">Update Relay</button>
-            <button id="stopBtn" type="button">Stop Relay</button>
-            <button id="refreshBtn" type="button">Show Status</button>
-        </form>
-    `;
-
-    configSelect = document.getElementById('configSelect');
-    loadConfigList();
-
-    document.getElementById('relayForm').onsubmit = function(e) {
-        e.preventDefault();
-        const outputUrls = document.getElementById('outputUrls').value
-            .split(/\n|,/)
-            .map(s => s.trim())
-            .filter(Boolean);
-        fetch('/api/start', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                input_url: document.getElementById('inputUrl').value,
-                output_urls: outputUrls
-            })
-        }).then(() => updateStatus());
-    };
-    document.getElementById('stopBtn').onclick = function() {
-        fetch('/api/stop', {method: 'POST'}).then(() => updateStatus());
-    };
-    document.getElementById('refreshBtn').onclick = updateStatus;
-    document.getElementById('saveBtn').onclick = function() {
-        const name = document.getElementById('saveName').value.trim();
-        if (!name) { alert('Enter a config name!'); return; }
-        const outputUrls = document.getElementById('outputUrls').value
-            .split(/\n|,/)
-            .map(s => s.trim())
-            .filter(Boolean);
-        fetch('/api/save-config', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                name,
-                input_url: document.getElementById('inputUrl').value,
-                output_urls: outputUrls
-            })
-        }).then(() => { alert('Config saved!'); loadConfigList(); });
-    };
-    document.getElementById('loadBtn').onclick = function() {
-        loadConfigByName(configSelect.value);
-    };
-    document.getElementById('deleteBtn').onclick = function() {
-        const name = configSelect.value;
-        if (!name) { alert('Select a config to delete!'); return; }
-        if (!confirm('Delete config "' + name + '"?')) return;
-        fetch('/api/delete-config?name=' + encodeURIComponent(name), {method: 'POST'})
-            .then(() => { alert('Config deleted!'); loadConfigList(); });
-    };
-    document.getElementById('cleanBtn').onclick = function() {
-        fetch('/api/clean-configs', {method: 'POST'})
-            .then(() => { alert('Cleaned empty/invalid configs!'); loadConfigList(); });
-    };
-    document.getElementById('exportBtn').onclick = function() {
-        window.location = '/api/export-configs';
-    };
-    document.getElementById('importBtn').onclick = function() {
-        document.getElementById('importFile').click();
-    };
-    document.getElementById('importFile').onchange = function(e) {
-        const file = e.target.files[0];
-        if (!file) return;
-        const formData = new FormData();
-        formData.append('file', file);
-        fetch('/api/import-configs', {
-            method: 'POST',
-            body: formData
-        }).then(() => { alert('Configs imported!'); loadConfigList(); });
-    };
-    configSelect.onchange = function() {
-        loadConfigByName(configSelect.value);
-    };
-
-    document.getElementById('updateBtn').onclick = function() {
-        const outputUrls = document.getElementById('outputUrls').value
-            .split(/\n|,/)
-            .map(s => s.trim())
-            .filter(Boolean);
-        fetch('/api/update', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                input_url: document.getElementById('inputUrl').value,
-                output_urls: outputUrls
-            })
-        })
-        .then(() => updateStatus());
-    };
-
-    updateStatus();
+    // Initial render
+    fetchStatus();
+    setInterval(fetchStatus, 5000);
 });

--- a/web/static/app.js
+++ b/web/static/app.js
@@ -59,7 +59,11 @@ document.addEventListener('DOMContentLoaded', function() {
                             <td style="word-break:break-all; padding:8px 12px;">${ep.output_url}</td>
                             <td style="padding:8px 12px;">${ep.running ? 'Running' : 'Stopped'}</td>
                             <td style="padding:8px 12px;">${ep.bitrate ? ep.bitrate : '-'}</td>
-                            <td style="padding:8px 12px;"><button class="stopRelayBtn" data-input="${input}" data-output="${ep.output_url}" ${!ep.running ? 'disabled' : ''}>Stop</button></td>
+                            <td style="padding:8px 12px;">
+                                ${ep.running
+                                    ? `<button class="stopRelayBtn" data-input="${input}" data-output="${ep.output_url}">Stop</button>`
+                                    : `<button class="startRelayBtn" data-input="${input}" data-output="${ep.output_url}">Start</button>`}
+                            </td>
                         </tr>`;
                     }
                 }
@@ -84,6 +88,17 @@ document.addEventListener('DOMContentLoaded', function() {
                 const input = btn.getAttribute('data-input');
                 const output = btn.getAttribute('data-output');
                 fetch('/api/relay/stop', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ input_url: input, output_url: output })
+                }).then(() => { fetchStatus(); });
+            };
+        });
+        document.querySelectorAll('.startRelayBtn').forEach(btn => {
+            btn.onclick = function() {
+                const input = btn.getAttribute('data-input');
+                const output = btn.getAttribute('data-output');
+                fetch('/api/relay/start', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ input_url: input, output_url: output })

--- a/web/static/index.html
+++ b/web/static/index.html
@@ -10,35 +10,6 @@
     <div id="controls">
         <!-- Controls will be populated by JS -->
     </div>
-    <div id="status">
-        <!-- Status info will appear here -->
-    </div>
-    <div id="logs-container" style="margin:24px 0 0 0; max-width:600px; width:100%; box-sizing:border-box;">
-        <div id="logs-header" style="cursor:pointer; background:#1976d2; color:#fff; padding:10px 16px; font-family:sans-serif; font-size:16px; border-radius:4px 4px 0 0; font-weight:500; letter-spacing:0.5px; box-shadow:0 1px 2px rgba(0,0,0,0.06);">
-            Logs &#9660;
-        </div>
-        <div id="logs" style="background:#f5f5f5; color:#222; padding:12px 16px; font-family:monospace; font-size:14px; max-height:220px; overflow:auto; display:block; border-radius:0 0 4px 4px; border:1px solid #ddd; border-top:none;"></div>
-            <!-- Logs will appear here -->
-        </div>
-    </div>
-    <script>
-        // Ensure logs-container aligns with controls and status
-        const controls = document.getElementById('controls');
-        const logsContainer = document.getElementById('logs-container');
-        if (controls && logsContainer) {
-            logsContainer.style.marginLeft = getComputedStyle(controls).marginLeft;
-            logsContainer.style.marginRight = getComputedStyle(controls).marginRight;
-        }
-
-        const logsHeader = document.getElementById('logs-header');
-        const logsDiv = document.getElementById('logs');
-        let logsCollapsed = false;
-        logsHeader.addEventListener('click', () => {
-            logsCollapsed = !logsCollapsed;
-            logsDiv.style.display = logsCollapsed ? 'none' : 'block';
-            logsHeader.innerHTML = `Logs ${logsCollapsed ? '&#9654;' : '&#9660;'}`;
-        });
-    </script>
     <script src="/static/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Starting prompt for the refactor

Each relay config will have one input url and multiple output url. The backend will use one ffmpeg process per input output URL pair. The user should be able to add relays and update relays dynamically without stopping unchanged relays. The UI will allow for user to import export config, start stop and update individual relays and output URL. The UI will have tabs to monitor individual relay pair stream health.